### PR TITLE
Support GCC 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ The images are uploaded to Dockerhub:
 - [gcc 5.3](https://hub.docker.com/r/lasote/conangcc53/)
 - [gcc 5.4](https://hub.docker.com/r/lasote/conangcc54/)
 - [gcc 6.2](https://hub.docker.com/r/lasote/conangcc62/)
+- [gcc 6.3](https://hub.docker.com/r/lasote/conangcc63/)

--- a/gcc_4.6/Dockerfile
+++ b/gcc_4.6/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Luis Martinez de Bartolome
 RUN  apt-get update && apt-get install -y python-dev sudo build-essential wget git vim libc6-dev-i386 g++-multilib nasm dh-autoreconf valgrind
 # RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Install CMake 3
-RUN wget https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.0-Linux-x86_64.tar.gz && cp -fR cmake-3.7.0-Linux-x86_64/* /usr && rm -rf cmake-3.7.0-Linux-x86_64 && rm cmake-3.7.0-Linux-x86_64.tar.gz
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz && cp -fR cmake-3.7.2-Linux-x86_64/* /usr && rm -rf cmake-3.7.2-Linux-x86_64 && rm cmake-3.7.2-Linux-x86_64.tar.gz
 RUN wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate && python get-pip.py && pip install -U pip
 RUN pip install conan
 RUN groupadd 1001 -g 1001

--- a/gcc_4.8/Dockerfile
+++ b/gcc_4.8/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Luis Martinez de Bartolome
 RUN dpkg --add-architecture i386 && rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python-dev sudo build-essential wget git vim libc6-dev-i386 g++-multilib nasm dh-autoreconf valgrind
 # RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Install CMake 3
-RUN wget https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.0-Linux-x86_64.tar.gz && cp -fR cmake-3.7.0-Linux-x86_64/* /usr && rm -rf cmake-3.7.0-Linux-x86_64 && rm cmake-3.7.0-Linux-x86_64.tar.gz
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz && cp -fR cmake-3.7.2-Linux-x86_64/* /usr && rm -rf cmake-3.7.2-Linux-x86_64 && rm cmake-3.7.2-Linux-x86_64.tar.gz
 RUN wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate && python get-pip.py && pip install -U pip
 RUN pip install conan
 RUN groupadd 1001 -g 1001

--- a/gcc_4.9/Dockerfile
+++ b/gcc_4.9/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Luis Martinez de Bartolome
 RUN dpkg --add-architecture i386 && rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python-dev sudo build-essential wget git vim libc6-dev-i386 g++-multilib nasm dh-autoreconf valgrind
 # RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Install CMake 3
-RUN wget https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.0-Linux-x86_64.tar.gz && cp -fR cmake-3.7.0-Linux-x86_64/* /usr && rm -rf cmake-3.7.0-Linux-x86_64 && rm cmake-3.7.0-Linux-x86_64.tar.gz
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz && cp -fR cmake-3.7.2-Linux-x86_64/* /usr && rm -rf cmake-3.7.2-Linux-x86_64 && rm cmake-3.7.2-Linux-x86_64.tar.gz
 RUN wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate && python get-pip.py && pip install -U pip
 RUN pip install conan
 RUN groupadd 1001 -g 1001

--- a/gcc_5.2/Dockerfile
+++ b/gcc_5.2/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Luis Martinez de Bartolome
 RUN dpkg --add-architecture i386 && rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python-dev sudo build-essential wget git vim libc6-dev-i386 g++-multilib nasm dh-autoreconf valgrind
 # RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Install CMake 3
-RUN wget https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.0-Linux-x86_64.tar.gz && cp -fR cmake-3.7.0-Linux-x86_64/* /usr && rm -rf cmake-3.7.0-Linux-x86_64 && rm cmake-3.7.0-Linux-x86_64.tar.gz
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz && cp -fR cmake-3.7.2-Linux-x86_64/* /usr && rm -rf cmake-3.7.2-Linux-x86_64 && rm cmake-3.7.2-Linux-x86_64.tar.gz
 RUN wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate && python get-pip.py && pip install -U pip
 RUN pip install conan
 RUN groupadd 1001 -g 1001

--- a/gcc_5.3/Dockerfile
+++ b/gcc_5.3/Dockerfile
@@ -6,7 +6,7 @@ RUN dpkg --add-architecture i386 && rm -rf /var/lib/apt/lists/* && apt-get updat
 RUN ln -s /usr/bin/g++-5 /usr/bin/g++
 # RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Install CMake 3
-RUN wget https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.0-Linux-x86_64.tar.gz && cp -fR cmake-3.7.0-Linux-x86_64/* /usr && rm -rf cmake-3.7.0-Linux-x86_64 && rm cmake-3.7.0-Linux-x86_64.tar.gz
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz && cp -fR cmake-3.7.2-Linux-x86_64/* /usr && rm -rf cmake-3.7.2-Linux-x86_64 && rm cmake-3.7.2-Linux-x86_64.tar.gz
 
 RUN wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate && python get-pip.py && pip install -U pip
 RUN pip install conan

--- a/gcc_5.4/Dockerfile
+++ b/gcc_5.4/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Luis Martinez de Bartolome
 RUN dpkg --add-architecture i386 && rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python-dev sudo build-essential wget git vim libc6-dev-i386 g++-multilib libgmp-dev libmpfr-dev libmpc-dev libc6-dev nasm dh-autoreconf valgrind
 # RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Install CMake 3
-RUN wget https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.0-Linux-x86_64.tar.gz && cp -fR cmake-3.7.0-Linux-x86_64/* /usr && rm -rf cmake-3.7.0-Linux-x86_64 && rm cmake-3.7.0-Linux-x86_64.tar.gz
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz && cp -fR cmake-3.7.2-Linux-x86_64/* /usr && rm -rf cmake-3.7.2-Linux-x86_64 && rm cmake-3.7.2-Linux-x86_64.tar.gz
 
 RUN wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate && python get-pip.py && pip install -U pip
 RUN pip install conan

--- a/gcc_6.2/Dockerfile
+++ b/gcc_6.2/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Luis Martinez de Bartolome
 RUN dpkg --add-architecture i386 && rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y python-dev sudo build-essential wget git vim libc6-dev-i386 g++-multilib libgmp-dev libmpfr-dev libmpc-dev libc6-dev nasm dh-autoreconf valgrind
 # RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 # Install CMake 3
-RUN wget https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.0-Linux-x86_64.tar.gz && cp -fR cmake-3.7.0-Linux-x86_64/* /usr && rm -rf cmake-3.7.0-Linux-x86_64 && rm cmake-3.7.0-Linux-x86_64.tar.gz
+RUN wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz && cp -fR cmake-3.7.2-Linux-x86_64/* /usr && rm -rf cmake-3.7.2-Linux-x86_64 && rm cmake-3.7.2-Linux-x86_64.tar.gz
 
 RUN wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate && python get-pip.py && pip install -U pip
 RUN pip install conan

--- a/gcc_6.3/Dockerfile
+++ b/gcc_6.3/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:zesty
+
+MAINTAINER Luis Martinez de Bartolome
+
+RUN dpkg --add-architecture i386 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get update \
+    && apt-get install -y python-dev sudo build-essential wget git vim libc6-dev-i386 g++-multilib libgmp-dev libmpfr-dev libmpc-dev libc6-dev nasm dh-autoreconf valgrind \
+    && wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz --no-check-certificate \
+    && tar -xzf cmake-3.7.2-Linux-x86_64.tar.gz \
+    && cp -fR cmake-3.7.2-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.7.2-Linux-x86_64 \
+    && rm cmake-3.7.2-Linux-x86_64.tar.gz \
+    && wget https://bootstrap.pypa.io/get-pip.py --no-check-certificate \
+    && python get-pip.py \
+    && pip install -U pip \
+    && pip install conan \
+    && groupadd 1001 -g 1001 \
+    && groupadd 1000 -g 1000 \
+    && useradd -ms /bin/bash conan -g 1001 -G 1000 \
+    && echo "conan:conan" | chpasswd \
+    && adduser conan sudo \
+    && echo "conan ALL= NOPASSWD: ALL\n" >> /etc/sudoers
+
+USER conan
+WORKDIR /home/conan
+RUN mkdir -p /home/conan/.conan

--- a/gcc_6.3/build.sh
+++ b/gcc_6.3/build.sh
@@ -1,0 +1,1 @@
+sudo docker build --no-cache -t lasote/conangcc63 .

--- a/gcc_6.3/run.sh
+++ b/gcc_6.3/run.sh
@@ -1,0 +1,1 @@
+sudo docker run --rm -v ~/.conan/data:/home/conan/.conan/data -it lasote/conangcc63 /bin/bash

--- a/rebuild_and_upload.py
+++ b/rebuild_and_upload.py
@@ -4,7 +4,7 @@ import sys
 
 if __name__ == "__main__":
         
-    for gcc_version in ["4.6", "4.8", "4.9", "5.2", "5.3", "5.4"]:
+    for gcc_version in ["4.6", "4.8", "4.9", "5.2", "5.3", "5.4", "6.2", "6.3"]:
         folder_name = "gcc_%s" % gcc_version
         image_name = "lasote/conangcc%s" % gcc_version.replace(".", "")
         os.system("cd %s && ./build.sh" % folder_name)


### PR DESCRIPTION
This PR adds a Ubuntu 17.04 container with GCC 6.3.
Also it updates CMake to v3.7.2 in all containers.

In contrast to the other containers I run most of the commands in one RUN.
This reduces the Docker layers and therefore the size of the container.

Example build log can be found here https://hub.docker.com/r/croydon/conan-gcc6-3-docker-test/builds/b2ffwq6qne4baxvdbmcyh3d/